### PR TITLE
Add miss rate

### DIFF
--- a/nomadWorkloadCPUActualsReport
+++ b/nomadWorkloadCPUActualsReport
@@ -189,11 +189,11 @@ def latch = new CountDownLatch(envs.size())
   def taskGroup
   def allocatedMHz
   def count
-  def missRate
   def hourStats
   def dayStats
   def weekStats
   def monthStats
+  def quarterYearStats
 }
 
 // loop through environments, start threads
@@ -369,6 +369,7 @@ while (latch.count > 0L) {
     if (containerStats.dayStats) addValuesToRow(row, containerStats.allocatedMHz, containerStats.dayStats)
     if (containerStats.weekStats) addValuesToRow(row, containerStats.allocatedMHz, containerStats.weekStats)
     if (containerStats.monthStats) addValuesToRow(row, containerStats.allocatedMHz, containerStats.monthStats)
+    if (containerStats.quarterYearStats) addValuesToRow(row, containerStats.allocatedMHz, containerStats.quarterYearStats)
   }
 }
 

--- a/nomadWorkloadCPUActualsReport
+++ b/nomadWorkloadCPUActualsReport
@@ -16,7 +16,9 @@ import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.TimeUnit
 import java.math.BigDecimal
 import java.math.MathContext
+import java.math.RoundingMode
 import groovy.json.JsonSlurper
+import groovy.lang.Delegate
 import groovy.transform.Canonical
 import org.apache.commons.math3.stat.descriptive.DescriptiveStatistics
 import org.apache.poi.ss.usermodel.FillPatternType
@@ -36,7 +38,7 @@ def defaultNomadTLSCertFilename = "${envReplacement}.nomad.key"
 def defaultNomadHost = "https://nomad.service.${envReplacement}-dc1.consul:4646"
 def defaultPrometheusHost = "http://prometheus-read.service.${envReplacement}-dc1.consul:9090"
 
-def cli = new CliBuilder(header: 'Nomad Workload CPU Actuals Report time periods; 1h, 1d, 7d, 30d', usage:'./nomadWorkloadCPUActualsReport -e <comma delimited environments> <other args>', width: -1, footer: "Environment queries are run in parallel to reduce report generation time. Use ${envReplacement} to inject environment into --nomadTLSKeyFilename, --nomadTLSCertFilename, --nomadHost, --prometheusHost")
+def cli = new CliBuilder(header: 'Nomad Workload CPU Actuals Report', usage:'./nomadWorkloadCPUActualsReport -e <comma delimited environments> <other args>', width: -1, footer: "Environment queries are run in parallel to reduce report generation time. Use ${envReplacement} to inject environment into --nomadTLSKeyFilename, --nomadTLSCertFilename, --nomadHost, --prometheusHost")
 cli.nca(longOpt: 'nomadTLSCACertFilename', "Nomad TLS CA Certificate Filename [defaults to ${defaultNomadTLSCACertFilename}]", args: 1, defaultValue: defaultNomadTLSCACertFilename)
 cli.nk(longOpt: 'nomadTLSKeyFilename', "Nomad TLS Certificate Filename [defaults to ${defaultNomadTLSKeyFilename}]", args: 1, defaultValue: defaultNomadTLSKeyFilename)
 cli.nc(longOpt: 'nomadTLSCertFilename', "Nomad TLS Key Filename [defaults to ${defaultNomadTLSCertFilename}]", args: 1, defaultValue: defaultNomadTLSCertFilename)
@@ -48,6 +50,7 @@ cli.d1h(longOpt: 'disableOneHourQuery', 'Disable 1 hour query')
 cli.d1d(longOpt: 'disableOneDayQuery', 'Disable 1 day query')
 cli.d7d(longOpt: 'disableSevenDayQuery', 'Disable 7 day query')
 cli.d30d(longOpt: 'disableThirtyDayQuery', 'Disable 30 day query')
+cli.e90d(longOpt: 'enableNinetyDayQuery', 'Enable 90 day query')
 cli.qst(longOpt: 'querySleepTime', args: 1, "Query sleep time in seconds [defaults to ${defaultQuerySleepTime}]", type: Long, defaultValue: defaultQuerySleepTime)
 cli.nh(longOpt: 'nomadHost', args: 1, "Nomad host [defaults to ${defaultNomadHost}]", defaultValue: defaultNomadHost)
 cli.ph(longOpt: 'prometheusHost', args: 1, "Prometheus host [defaults to ${defaultPrometheusHost}]", defaultValue: defaultPrometheusHost)
@@ -78,15 +81,17 @@ def perTaskQuerySleepTime = TimeUnit.SECONDS.toMillis(cliOptions.querySleepTime)
 
 def queuePollWait = 5L
 def mathContext = new MathContext(14)
+def missRateMathContext = new MathContext(2, RoundingMode.HALF_UP)
 
 // header values used for each sheet in the excel doc
-def perQueryWindowMetrics = ['Mean', 'p50', 'p95', 'Max', 'Std Dev', 'Kurtosis', 'Skewness']
+def perQueryWindowMetrics = ['Miss Rate', 'Mean', 'p50', 'p95', 'Max', 'Std Dev', 'Kurtosis', 'Skewness']
 def headerValues = ['Job', 'Task Group', 'Allocated', 'Container Count']
 
 if (!cliOptions.disableOneHourQuery) headerValues.addAll(perQueryWindowMetrics.collect { metric -> "1 Hr ${metric}" })
 if (!cliOptions.disableOneDayQuery) headerValues.addAll(perQueryWindowMetrics.collect { metric -> "1 Day ${metric}" })
 if (!cliOptions.disableSevenDayQuery) headerValues.addAll(perQueryWindowMetrics.collect { metric -> "7 Day ${metric}" })
 if (!cliOptions.disableThirtyDayQuery) headerValues.addAll(perQueryWindowMetrics.collect { metric -> "30 Day ${metric}" })
+if (cliOptions.enableNinetyDayQuery) headerValues.addAll(perQueryWindowMetrics.collect { metric -> "90 Day ${metric}" })
 
 // workbook for excel doc, font for header
 def workbook = new XSSFWorkbook()
@@ -134,6 +139,12 @@ def styleCellForValues = { allocated, actual ->
 // takes a pre-created poi row and adds cells for the stats results
 def addValuesToRow = { row, allocated, stats ->
 
+  def missRateCell = row.createCell(row.getLastCellNum())
+  def missResults = new BigDecimal(stats.missResults, missRateMathContext)
+  def missRate = missResults.divide(new BigDecimal(stats.totalResults, missRateMathContext), missRateMathContext)
+  def missPercentage = missRate.movePointRight(2)
+  missRateCell.setCellValue("% ${missPercentage.toString()}")
+
   def meanCell = row.createCell(row.getLastCellNum())
   def mean = stats.mean as Integer
   meanCell.setCellValue(mean)
@@ -163,6 +174,13 @@ def addValuesToRow = { row, allocated, stats ->
 def queue = new LinkedBlockingQueue(1)
 def latch = new CountDownLatch(envs.size())
 
+@Canonical class StatsWithMissData {
+
+  @Delegate DescriptiveStatistics stats
+  def totalResults
+  def missResults
+}
+
 // class that allows for data movement through processing threads to background thread
 @Canonical class ContainerStats {
 
@@ -171,6 +189,7 @@ def latch = new CountDownLatch(envs.size())
   def taskGroup
   def allocatedMHz
   def count
+  def missRate
   def hourStats
   def dayStats
   def weekStats
@@ -245,6 +264,9 @@ envs.each { environment ->
 
       def sumStats = new DescriptiveStatistics()
 
+      def totalResults = 0
+      def missResults = 0
+
       try {
 
         def parsedResponse = slurper.parse(url.toURL())
@@ -253,15 +275,19 @@ envs.each { environment ->
 
           result.values.each { value ->
 
+            totalResults++
+
             def snapshotCPUTotalPercent = new BigDecimal(value.last(), mathContext)
-            def snapshotCPUAsLoadAverage = snapshotCPUTotalPercent.movePointLeft(2)        
+            def snapshotCPUAsLoadAverage = snapshotCPUTotalPercent.movePointLeft(2)
 
             if (nomadClientsToCPUFrequency.containsKey(result.metric.host)) {
               sumStats.addValue(snapshotCPUAsLoadAverage.multiply(nomadClientsToCPUFrequency.get(result.metric.host)).doubleValue())
             } else if (cliOptions.avgKnownNomadClients) {
               sumStats.addValue(snapshotCPUAsLoadAverage.multiply(averageKnownClientFrequency).doubleValue())
+              missResults++
             } else {
               sumStats.addValue(snapshotCPUAsLoadAverage.multiply(cliOptions.nomadFallbackClock).doubleValue())
+              missResults++
             }
           }
         }
@@ -271,7 +297,7 @@ envs.each { environment ->
         println "Error occurred in opening, parsing, and processing results from prometheus for url ${url}, exception: ${exception}"
       }
 
-      sumStats
+      new StatsWithMissData(sumStats, totalResults, missResults)
     }
 
     // loop through each job, task group and query prometheus
@@ -291,7 +317,8 @@ envs.each { environment ->
           cliOptions.disableOneHourQuery ? null : slurpAndReport("${prometheusQueryBase}[30s])[1h:30s]"),
           cliOptions.disableOneDayQuery ? null : slurpAndReport("${prometheusQueryBase}[5m])[1d:5m]"),
           cliOptions.disableSevenDayQuery ? null : slurpAndReport("${prometheusQueryBase}[30m])[7d:30m]"),
-          cliOptions.disableThirtyDayQuery ? null : slurpAndReport("${prometheusQueryBase}[1h])[30d:1h]")))
+          cliOptions.disableThirtyDayQuery ? null : slurpAndReport("${prometheusQueryBase}[1h])[30d:1h]"),
+          cliOptions.enableNinetyDayQuery ? slurpAndReport("${prometheusQueryBase}[6h])[90d:6h]") : null))
 
         prometheusTaskGroupQueryStopwatch.stop()
         println "Finished querying prometheus for ${environment}, job ${job} and task group ${taskGroup} in ${prometheusTaskGroupQueryStopwatch.elapsed(TimeUnit.MILLISECONDS)} ms"


### PR DESCRIPTION
- Adds support for 90 day query
- Adds support for a miss rate, providing a percentage of the data coming from prometheus that references nomad hosts that are no longer part of the cluster and thus use the fallback or averaged accounting method